### PR TITLE
Added Option to redirect if event cant be found instead of error message

### DIFF
--- a/Configuration/TypoScript/ts/constants.txt
+++ b/Configuration/TypoScript/ts/constants.txt
@@ -5,7 +5,10 @@
 plugin.tx_cal_controller {
 	# cat=Calendar Base (General)/general/pidlist/1; type=string; label=Page ID where events are stored.  Required for ICS and XML output.
 	pidList =
-	
+
+	# cat=Calendar Base (General)/general/emptyEventPid/2; type=string; label=Page ID the visitor should get redirected to when the detail view event id is not available (e.g. during change of language)
+	emtyEventPid =
+
 	# cat=Calendar Base (General)/dims/110; type=int+; label= Event Image Max Width: Max width for an image displayed in Event view.
 	singleMaxW = 240
 		  

--- a/Configuration/TypoScript/ts/setup.txt
+++ b/Configuration/TypoScript/ts/setup.txt
@@ -12,6 +12,9 @@ plugin.tx_cal_controller {
 	# @description	List of PIDs where cal records are found.
 	pidList = {$plugin.tx_cal_controller.pidList}
 
+	#@description  Page ID the visitor should get redirected to when the detail view event id is not available (e.g. during change of language)
+	emtyEventPid = {$plugin.tx_cal_controller.emptyEventPid}
+
 	# @description	List of csv of piVars, which should not appear in the url, but should be stored inside the users session. Attention: this works only, if the piVar is the same through a whole single page
 	sessionPiVars = page_id
 

--- a/Documentation/Advanced/TyposcriptReferenceConstants/Index.rst
+++ b/Documentation/Advanced/TyposcriptReferenceConstants/Index.rst
@@ -38,6 +38,19 @@ plugin.tx\_cal\_controller
 
    Default
 
+.. container:: table-row
+
+   Property
+         emtyEventPid
+
+   Data type
+         String
+
+   Description
+         Page ID the visitor should get redirected to when the detail view event id is not available (e.g. during change of language)
+
+   Default
+
 
 .. container:: table-row
 


### PR DESCRIPTION
We added the functionality to redirect to a ts configured pid in case no event can be found in detail view instead of displaying the error message "Missing or wrong parameter. The event you are looking for could not be found."

I needed this behavior when changing languages on a detail view and that event is not translated into destination language. In that case the user sees a red error message wich is not that great in production use. With this small added function we can define a fallback pid that can get redirected to. This could be the list view page or a custom beautiful "sorry that event is not available in your desired language" page.
The pid is configured via typoscript (I added documnetation) and is fully backward compatible. In case no pid is defined it still displays the error message (old behaviour).

Thanks for your great ext!  – Raphael

In case you'd rather me commiting my changes somewhere else, I'd be happy to do so.
